### PR TITLE
override action name

### DIFF
--- a/jquery.tabledit.js
+++ b/jquery.tabledit.js
@@ -33,6 +33,7 @@ if (typeof jQuery === 'undefined') {
             warningClass: 'warning',
             mutedClass: 'text-muted',
             eventType: 'click',
+            overrideAction: 'action',
             rowIdentifier: 'id',
             hideIdentifier: false,
             autoFocus: true,
@@ -369,7 +370,7 @@ if (typeof jQuery === 'undefined') {
          */
         function ajax(action)
         {
-            var serialize = $table.find('.tabledit-input').serialize() + '&action=' + action;
+            var serialize = $table.find('.tabledit-input').serialize()  + '&' + settings.overrideAction + '=' + action;
 
             var result = settings.onAjax(action, serialize);
 


### PR DESCRIPTION
For users on the Zend Framework, using the parameter action means it will get overriden by the action being processed by the ZF.  Therefore, added extra setting to override this.
